### PR TITLE
Include serviceoutput for HTML versions

### DIFF
--- a/skins.mail/service.ACKNOWLEDGEMENT
+++ b/skins.mail/service.ACKNOWLEDGEMENT
@@ -153,9 +153,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.DOWNTIMECANCELLED
+++ b/skins.mail/service.DOWNTIMECANCELLED
@@ -157,9 +157,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.DOWNTIMEEND
+++ b/skins.mail/service.DOWNTIMEEND
@@ -158,9 +158,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.DOWNTIMESTART
+++ b/skins.mail/service.DOWNTIMESTART
@@ -158,9 +158,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.FLAPPINGDISABLED
+++ b/skins.mail/service.FLAPPINGDISABLED
@@ -156,9 +156,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.FLAPPINGSTART
+++ b/skins.mail/service.FLAPPINGSTART
@@ -156,9 +156,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.FLAPPINGSTOP
+++ b/skins.mail/service.FLAPPINGSTOP
@@ -156,9 +156,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.PROBLEM
+++ b/skins.mail/service.PROBLEM
@@ -154,9 +154,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.RECOVERY
+++ b/skins.mail/service.RECOVERY
@@ -154,9 +154,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/skins.mail/service.default
+++ b/skins.mail/service.default
@@ -154,9 +154,9 @@ Content-Type: text/html; charset=utf-8
                       Service notes: #SERVICENOTESURL#
                       <br>
                       <br>
-                      <strong>Long output:</strong><br>
+                      <strong>Output:</strong><br>
                       <br>
-                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#LONGSERVICEOUTPUT#</pre>
+                      <pre style="display: block;padding: 9.5px;margin: 0 0 10px;font-size: 13px;line-height: 1.42857143;color: #333;word-break: break-all;word-wrap: break-word;background-color: #f5f5f5;border: 1px solid #ccc;border-radius: 4px;font-family: Menlo,Monaco,Consolas,&quot;Courier New&quot;,monospace;overflow: auto;">#SERVICEOUTPUT#<br />#LONGSERVICEOUTPUT#</pre>
                     </td>
                   </tr>
                   <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">


### PR DESCRIPTION
Previously only `LONGOUTPUT` was displayed in the HTML service e-mails.
With this commit both `SERVICE` and `LONGSERVICEOUTPUT` is displayed.

Signed-off-by: Jacob Hansen <jhansen@op5.com>